### PR TITLE
Fix build on linux with musl

### DIFF
--- a/src/qmidictlUdpDevice.cpp
+++ b/src/qmidictlUdpDevice.cpp
@@ -34,6 +34,7 @@ inline void closesocket(int s) { ::close(s); }
 static WSADATA g_wsaData;
 typedef int socklen_t;
 #else
+#include <sys/select.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
 inline void closesocket(int s) { ::close(s); }


### PR DESCRIPTION
Build fails for unknown FD_ZERO which is defined in [1]. Somehow musl is again
more picky on this so add #include <sys/select.h>

[1] http://man7.org/linux/man-pages/man2/select.2.html

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>